### PR TITLE
Fix parsing /proc/net/dev when device name has '-'

### DIFF
--- a/net/DeviceMonitor.js
+++ b/net/DeviceMonitor.js
@@ -94,7 +94,7 @@ class DeviceMonitorClass {
         for (let index = 2; index < lines.length - 1; ++index) {
             const line = lines[index].trim();
             logger.debug(`${index} - ${line}`);
-            const fields = line.split(/\W+/);
+            const fields = line.split(/[^A-Za-z0-9_-]+/);
             const deviceName = fields[0];
 
             if (deviceName == "lo")

--- a/net/NetworkMonitor.js
+++ b/net/NetworkMonitor.js
@@ -72,7 +72,7 @@ class NetworkMonitorClass {
         for (let index = 2; index < lines.length - 1; ++index) {
             const line = lines[index].trim();
             //logger.debug(`${index} - ${line}`);
-            const fields = line.split(/\W+/);
+            const fields = line.split(/[^A-Za-z0-9_-]+/);
             const deviceName = fields[0];
 
             if (deviceName == "lo")


### PR DESCRIPTION
Encountered this issue after I restarted GNOME Shell with Alt+F2, `r`.

```
JS ERROR: Extension network-stats@gnome.noroadsleft.xyz: TypeError: device is null
_getIPAddress@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/net/DeviceMonitor.js:173:13
_loadDevices@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/net/DeviceMonitor.js:108:36
init@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/net/DeviceMonitor.js:76:14
DeviceMonitorClass@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/net/DeviceMonitor.js:23:14
DeviceModelClass@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/net/DeviceModel.js:23:31
AppController@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/AppController.js:30:29
@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/AppController.js:208:21
@/home/kramer/.local/share/gnome-shell/extensions/network-stats@gnome.noroadsleft.xyz/extension.js:6:27
_callExtensionInit@resource:///org/gnome/shell/ui/extensionSystem.js:422:13
loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:347:27
_loadExtensions/<@resource:///org/gnome/shell/ui/extensionSystem.js:588:18
collectFromDatadirs@resource:///org/gnome/shell/misc/fileUtils.js:27:28
_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:567:19
_enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:597:18
_sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:628:18
init@resource:///org/gnome/shell/ui/extensionSystem.js:56:14
_initializeUI@resource:///org/gnome/shell/ui/main.js:269:22
start@resource:///org/gnome/shell/ui/main.js:159:5
@<main>:1:47
```

Turns out I have a network device named `br-c345d17ca011` that was spawned up from Docker since the extension was last loaded. The issue was that the device name was being parsed as `br`, explaining why `device` is null. This PR expands the regex used to parse `/proc/net/dev` so it takes hyphens into account when fetching the device names.