### PR TITLE
Fixed right click not working to change display mode.

### DIFF
--- a/AppSettingsModel.js
+++ b/AppSettingsModel.js
@@ -141,6 +141,7 @@ class AppSettingsModel {
 
     subscribe(listener) {
         this._settingListeners.push(listener);
+        return listener;
     }
 
     unsubscribe(listener) {
@@ -148,6 +149,7 @@ class AppSettingsModel {
         if (index != -1) {
             this._settingListeners.splice(index, 1);
         }
+        return listener;
     }
 }
 


### PR DESCRIPTION
Right click was not working to change the display mode.
once the machine is wake up from hybernation.
Had to unsubscribe old registered settings listener refering to old UI objects.