### PR TITLE
Fix: Restore selected font size correctly on startup and update default label font size

### DIFF
--- a/lib/AppController.ts
+++ b/lib/AppController.ts
@@ -37,7 +37,6 @@ export class AppController {
         Broadcasters.titleClickedMessageBroadcaster?.subscribe(this.onRightClick);
         this._appSettingsModel.subscribe(this.onSettingChanged);
         this.installTimers();
-        this._appView.setTitleTextSize(this._appSettingsModel.statusFontSize);
     }
 
     /**
@@ -87,6 +86,8 @@ export class AppController {
      */
     show() {
         this._appView.show();
+        const sz = Math.max(10, this._appSettingsModel.statusFontSize || 14);
+        this._appView.setTitleTextSize(sz);
     }
 
     /**

--- a/lib/ui/AppView.ts
+++ b/lib/ui/AppView.ts
@@ -106,11 +106,12 @@ export class AppView {
      * @param size - text size
      */
     setTitleTextSize(size: number): void {
-        if (this._statusFontSize !== size && size >= 10) {
-            this._statusFontSize = size;
-            this._label.style += `font-size: ${size}px`;
+        if (size >= 10) {
+            const sz = Math.max(10, size || 14);
+            this._statusFontSize = sz;
+            this._label.style += `font-size: ${sz}px;`;
             if (this._popupView) {
-                this._popupView.setTitleTextSize(size);
+                this._popupView.setTitleTextSize(sz);
             }
         }
     }

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -29,7 +29,7 @@
 }
 
 .main-label {
-    font-size: 0.8em;
+    font-size: 1em;
 }
 
 .device-menu-item {


### PR DESCRIPTION
This pull request fixes an issue where the selected font size would reset to the default after a system reboot or extension reload.
Although the font size preference was stored correctly in settings, it was not applied to the UI during initialization.

#### **Changes made**

* Applied the stored font size setting in the `show()` function to ensure it takes effect on startup.
* Added validation to ensure font size values are correctly applied before use.
* Updated the stylesheet to reflect the new default label font size.

#### **Result**

* User’s chosen font size now persists correctly after restarting the system or reloading the extension.
* The UI reflects the stored settings immediately without requiring the user to reopen or adjust settings manually.
