### PR TITLE
feat: add support for GNOME 50

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,7 @@
     "uuid": "network-stats@gnome.noroadsleft.xyz",
     "settings-schema": "org.gnome.shell.extensions.network-stats",
     "gettext-domain": "network-stats",
-    "shell-version": ["45", "46", "47", "48", "49"],
+    "shell-version": ["45", "46", "47", "48", "49", "50"],
     "url": "https://github.com/noroadsleft000/gnome-network-stats",
     "version": 32
 }


### PR DESCRIPTION
### Description:
Bumped shell-version to include GNOME 50.

### Testing Notes:

- Tested locally on Fedora 44 (Wayland).

- The extension compiles correctly, and stats update on the panel as expected.

- Verified the Preferences window opens and saves correctly.

- Monitored `journalctl` during operation; no `JS ERROR` or deprecation warnings are thrown.